### PR TITLE
Fix bar chart dataset

### DIFF
--- a/src/app/graphs/page.tsx
+++ b/src/app/graphs/page.tsx
@@ -79,7 +79,7 @@ import PageContainer from "../components/pagecontainer";
             <Doughnut data={chartData} />
           </div>
           <div className="w-[600px]">
-            <Bar data={chartData} options={barOptions} />
+            <Bar data={barData} options={barOptions} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- correct bar chart to use its own data set rather than doughnut data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68988f7085f0833192fdd697b09c1661